### PR TITLE
Move 2023 articles from /2024/ to /2023/ folder

### DIFF
--- a/_layouts/articles.md
+++ b/_layouts/articles.md
@@ -28,13 +28,13 @@
 <ul class="ulnone">
         <li class="large">
             <u style="font-size: small;">Sep 23</u> <br>
-            <a href="/articles/2024/marg.html">Marginalia</a><br>
+            <a href="/articles/2023/marg.html">Marginalia</a><br>
             <hr class="linebreak">
             <u style="font-size: small;">Sep 23</u><br>
-            <a href="/articles/2024/xpev.html">Using the Xonsh shell to Modify Environment Variables</a><br>
+            <a href="/articles/2023/xpev.html">Using the Xonsh shell to Modify Environment Variables</a><br>
             <hr class="linebreak">
             <u style="font-size: small;">May 23</u><br>
-            <a  href="/articles/2024/otcd.html">OpenTrack Crash Troubleshooting</a><br>
+            <a  href="/articles/2023/otcd.html">OpenTrack Crash Troubleshooting</a><br>
             <hr class="linebreak">
         </li>
 </ul>

--- a/articles/2023/marg.md
+++ b/articles/2023/marg.md
@@ -10,7 +10,7 @@ layout: article
 * auto-gen TOC:
 {:toc}
 
-<a class="prev" href="/articles/2024/xpev"> < </a>
+<a class="prev" href="/articles/2023/xpev"> < </a>
 <a class="next" href="/articles/2024/useyt"> > </a>
 
 ## Return to Earth
@@ -54,9 +54,9 @@ As for the ancillary issue, well... people have always believed wacky things, ri
   [1] - YouTube now allows (and heavily promotes) community posts, which
   essentially function the same as
   Instagram posts for major news outlets -- except the comments tend to be even more conspiratorial and
-  deranged <a class="inline" href="/articles/2024/marg#fn1ref">↩</a><br>
+  deranged <a class="inline" href="/articles/2023/marg#fn1ref">↩</a><br>
   [2] - <a id="2"  target="_blank" 
     href="https://www.monmouth.edu/polling-institute/documents/monmouthpoll_us_092722.pdf/">pg 7, In a poll conducted in
     Sep 2022, 61% of Republicans believe Joe Biden won the 2020 election "due to voter fraud" [monmouth.edu]</a> <a
-    class="inline" href="/articles/2024/marg#fn2ref">↩</a><br>
+    class="inline" href="/articles/2023/marg#fn2ref">↩</a><br>
 </p> -->

--- a/articles/2023/otcd.md
+++ b/articles/2023/otcd.md
@@ -11,7 +11,7 @@ layout: article
 {:toc}
 
 <a class="prev"> < </a>
-<a class="next" href="/articles/2024/xpev"> > </a>
+<a class="next" href="/articles/2023/xpev"> > </a>
 
 <p> <em>Recently, I collaborated in diagnosing and resolving an issue with OpenTrack (OT), a FOSS
         head-tracking

--- a/articles/2023/xpev.md
+++ b/articles/2023/xpev.md
@@ -10,7 +10,7 @@ layout: article
 * auto-gen TOC:
 {:toc}
 
-<a class="prev" href="/articles/2024/otcd"> < </a> <a class="next" href="/articles/2024/marg"> > </a>
+<a class="prev" href="/articles/2023/otcd"> < </a> <a class="next" href="/articles/2023/marg"> > </a>
     
 Xonsh is a "Python-powered, cross-platform, Unix-gazing shell language and command prompt."[^1]Many operations that are clumsy in Windows natively are comparatively simple using the Xonsh shell. Let's take a look at one example, modifying the PATH environment variable.In Windows 11 without Xonsh, modifying your PATH environment variable can be done in either the "Environment Variables" window or by updating this key [^2].
 

--- a/articles/2024/useyt.md
+++ b/articles/2024/useyt.md
@@ -9,14 +9,14 @@ layout: article
 
 * auto-gen TOC:
 {:toc}
-<a class="prev" href="/articles/2024/marg"> < </a>
+<a class="prev" href="/articles/2023/marg"> < </a>
 <a class="next" href="/articles/2024/wwwtsql"> > </a>
 
 
 <p>
             Have you ever noticed that YouTube is way worse than it used to be? It's time we got rid of YouTube shorts,
             sponsors, clickbait titles and thumbnails, and those <a class="inline"  target="_blank" 
-                href="/articles/2024/marg">insane comments.</a> The goal of this post is to help you
+                href="/articles/2023/marg">insane comments.</a> The goal of this post is to help you
             enhance YouTube so that it resembles the good old days... or at least makes it usable.
         </p>
 <h2><a class="inline" target="_blank" href="https://www.youtube.com/watch?v=Sa47RKkZV8E"

--- a/articles/tags/ai.md
+++ b/articles/tags/ai.md
@@ -3,4 +3,4 @@ layout: article
 ---
 
 ## Articles tagged "AI"
-- [Marginalia](/articles/2024/marg)
+- [Marginalia](/articles/2023/marg)

--- a/articles/tags/debugging.md
+++ b/articles/tags/debugging.md
@@ -3,4 +3,4 @@ layout: article
 ---
 
 ## Articles tagged "debugging"
-- [OpenTrack Crash Troubleshooting](/articles/2024/otcd)
+- [OpenTrack Crash Troubleshooting](/articles/2023/otcd)

--- a/articles/tags/internet.md
+++ b/articles/tags/internet.md
@@ -3,4 +3,4 @@ layout: article
 ---
 
 ## Articles tagged "Internet"
-- [Marginalia](/articles/2024/marg)
+- [Marginalia](/articles/2023/marg)

--- a/articles/tags/software.md
+++ b/articles/tags/software.md
@@ -3,7 +3,7 @@ layout: article
 ---
 
 ## Articles tagged "Software"
-- [Marginalia](/articles/2024/marg)
+- [Marginalia](/articles/2023/marg)
 - [Replace Start Menu on Windows](/articles/2024/replacestart)
 - [What's all wrong with this SQL?](/articles/2024/wwwtsql)
-- [Xonsh](/articles/2024/xpev)
+- [Xonsh](/articles/2023/xpev)


### PR DESCRIPTION
- Created /articles/2023/ folder
- Moved xpev.md, otcd.md, and marg.md from 2024 to 2023 folder
- Fixed all broken links in navigation, tags, and cross-references
- Updated articles layout page with correct paths

🤖 Generated with [Claude Code](https://claude.ai/code)